### PR TITLE
Update __init__.py

### DIFF
--- a/blender_atomic_loader/__init__.py
+++ b/blender_atomic_loader/__init__.py
@@ -317,6 +317,7 @@ def get_bonds(aseframe,cutoff=default_bond_cutoff):
     for i,dists in enumerate(dist_mat):
         bond_list.append([np.sort([i,j]) for j in np.where(dists<cutoff)[0] if i!=j])
     # returne the list of unique bonds
+    bond_list = [x for x in bond_list if x != []]
     return np.asarray(list(set([tuple(i) for i in np.concatenate(bond_list)])))
 
 def split_bonds(aseframe,cutoff=default_bond_cutoff):

--- a/blender_atomic_loader/__init__.py
+++ b/blender_atomic_loader/__init__.py
@@ -318,6 +318,8 @@ def get_bonds(aseframe,cutoff=default_bond_cutoff):
         bond_list.append([np.sort([i,j]) for j in np.where(dists<cutoff)[0] if i!=j])
     # returne the list of unique bonds
     bond_list = [x for x in bond_list if x != []]
+    if bond_list == []:
+        bond_list = [[]]
     return np.asarray(list(set([tuple(i) for i in np.concatenate(bond_list)])))
 
 def split_bonds(aseframe,cutoff=default_bond_cutoff):


### PR DESCRIPTION
bug fixed for existing distance > cutoff, error information is shown below.

  _File "E:\blender290\2.90\python\lib\site-packages\blender_atomic_loader\__init__.py", line 323, in get_bonds
    return np.asarray(list(set([tuple(i) for i in np.concatenate(bond_list)])))
  File "<__array_function__ internals>", line 6, in concatenate
ValueError: all the input arrays must have same number of dimensions, but the array at index 0 has 2 dimension(s) and the array at index 4 has 1 dimension(s)
Error: Python script failed, check the message in the system console_

The bondlist for (Trifluoromethyl)silane molecule is _[[array([0, 1], dtype=int64), array([0, 2], dtype=int64), array([0, 3], dtype=int64)], [array([0, 1], dtype=int64)], [array([0, 2], dtype=int64)], [array([0, 3], dtype=int64)], **[]**]_ with a empty list.